### PR TITLE
Updated configuration instructions to reflect new klipper features

### DIFF
--- a/LEDs/Rainbow_Barf_Logo_LED/Code/stealthburner_led_effects_barf.cfg
+++ b/LEDs/Rainbow_Barf_Logo_LED/Code/stealthburner_led_effects_barf.cfg
@@ -14,8 +14,7 @@
 #     2.  Define your LEDs by editing [neopixel sb_leds] below and entering the data pin from your control board
 #         as well as the color order.
 #
-#           Note: RGB and RGBW are different and must be defined explicitly.  RGB and RGBW are also not able to 
-#                 be mix-and-matched in the same chain. A separate data line would be needed for proper functioning.
+#           Note: RGB and RGBW are different and must be defined explicitly.
 #
 #                 RGBW LEDs will have a visible yellow-ish phosphor section to the chip.  If your LEDs do not have
 #                 this yellow portion, you have RGB LEDs.
@@ -45,8 +44,7 @@
 #
 #     5.  Feel free to change colors of each macro, create new ones if you have a need to.  The macros provided below
 #         are just an example of what is possible.  If you want to try some more complex animations, you will most
-#         likely have to use WLED with Moonraker and a small micro-controller (please see the LED thread for help inside
-#         of the stealthburner_beta channel on Discord).
+#         likely have to use the Klipper LED Effect plugin: https://github.com/julianschill/klipper-led_effect
 #
 #####################################
 #       END INSTRUCTRUCTIONS        #


### PR DESCRIPTION
Hi, I noticed that the example configuration file contains some instructions that are now obsolete, so I made this small PR to reflect those changes.

In particular:

- I removed the sentence that said that it is impossible to mix and match RGB and RGBW neopixels
- I replaced the reference to WLED with the LED effects plugin for klipper